### PR TITLE
Add image loading (-imagecmd) and minimal <object> support

### DIFF
--- a/minhtmltk0.tcl
+++ b/minhtmltk0.tcl
@@ -251,6 +251,7 @@ snit::widget minhtmltk {
 
     method Reset {} {
         $myHtml reset
+        $self image reset
         foreach form [list {*}$stateFormList $stateOuterForm] {
             if {$form eq ""} continue
             $form destroy
@@ -288,12 +289,14 @@ snit::widget minhtmltk {
     ::minhtmltk::taghelper style
     ::minhtmltk::taghelper anchor
     ::minhtmltk::taghelper link
+    ::minhtmltk::taghelper imagecmd
+    ::minhtmltk::taghelper object
 
     # To be handled
     list {
         button
         iframe menu
-        base meta title object embed
+        base meta title embed
     }
 
     method install-html-handlers {} {

--- a/taghelper/imagecmd.tcl
+++ b/taghelper/imagecmd.tcl
@@ -1,0 +1,70 @@
+# -*- mode: tcl; coding: utf-8 -*-
+
+namespace eval ::minhtmltk::taghelper {}
+
+#
+# Image loading support (-imagecmd) for the bare file:/data: world of
+# minhtmltk. Loaded images are cached per URI; the cache is flushed by
+# [image reset], which is called from the widget's Reset method.
+#
+snit::macro ::minhtmltk::taghelper::imagecmd {} {
+
+    variable stateImageCache -array {}
+
+    method {image install} {} {
+        $myHtml configure -imagecmd [list $self image load]
+    }
+
+    method {image reset} {} {
+        foreach {uri img} [array get stateImageCache] {
+            catch {image delete $img}
+        }
+        array unset stateImageCache
+        $self image install
+    }
+
+    # Called by Tkhtml for <img src=...>, css background-image url(...)
+    # and -tkhtml-replacement-image. Returns a Tk photo image name, or
+    # "" if the image can not be loaded.
+    method {image load} uri {
+        if {[info exists stateImageCache($uri)]} {
+            return $stateImageCache($uri)
+        }
+        set img ""
+        catch {set img [$self image create-from $uri]}
+        if {$img ne ""} {
+            set stateImageCache($uri) $img
+        }
+        return $img
+    }
+
+    method {image create-from} uri {
+        if {[regexp {^data:image/[^;,]+;base64,(.*)$} $uri -> b64]} {
+            # data: URIs may be %-encoded (e.g. %2F for '/').
+            set b64 [::minhtmltk::taghelper::percent-decode $b64]
+            return [image create photo -data $b64]
+        }
+        if {[regexp {^data:} $uri]} {
+            return ""
+        }
+        set resolved [$self nav resolve $uri]
+        set uriObj [tkhtml::uri $resolved]
+        ::minhtmltk::utils::scope_guard uriObj [list $uriObj destroy]
+        if {[$uriObj scheme] ni {file ""}} {
+            return ""
+        }
+        set path [$uriObj path]
+        if {![file readable $path]} {
+            return ""
+        }
+        image create photo -file $path
+    }
+}
+
+namespace eval ::minhtmltk::taghelper {
+    # %XX decoding only ('+' is kept as-is; this is not a query string).
+    proc percent-decode str {
+        regsub -all {%([0-9A-Fa-f]{2})} $str {\\u00\1} str
+        subst -novariables -nocommands $str
+    }
+}

--- a/taghelper/link.tcl
+++ b/taghelper/link.tcl
@@ -10,6 +10,17 @@ snit::macro ::minhtmltk::taghelper::link {} {
     method {add node link} node {
         if {[set rel [$node attr -default "" rel]] eq ""} return
 
+        # rel is a space separated list of words: "stylesheet",
+        # "appendix stylesheet", "alternate stylesheet" etc. Alternate
+        # stylesheets (with a title) are not applied by default.
+        set words [string tolower $rel]
+        if {"stylesheet" in $words} {
+            if {"alternate" in $words
+                && [$node attr -default "" title] ne ""} return
+            $self link-rel stylesheet add $node
+            return
+        }
+
         # puts "link-rel $rel add $node"
         $self link-rel $rel add $node
     }

--- a/taghelper/object.tcl
+++ b/taghelper/object.tcl
@@ -1,0 +1,23 @@
+# -*- mode: tcl; coding: utf-8 -*-
+
+namespace eval ::minhtmltk::taghelper {}
+
+::minhtmltk::taghelper::add node object
+
+#
+# Minimal <object> support: if the data attribute points to a loadable
+# image, render the object as a replaced element showing that image.
+# Otherwise leave the fallback content (which may be a nested <object>)
+# in place. This is the behavior the Acid2 eyes rely on.
+#
+snit::macro ::minhtmltk::taghelper::object {} {
+
+    method {add node object} node {
+        set data [$node attr -default "" data]
+        if {$data eq ""} return
+
+        if {[$self image load $data] ne ""} {
+            $node override [list -tkhtml-replacement-image url($data)]
+        }
+    }
+}

--- a/taghelper/style.tcl
+++ b/taghelper/style.tcl
@@ -10,6 +10,14 @@ snit::macro ::minhtmltk::taghelper::style {} {
     method {link-rel stylesheet add} node {
         if {[set href [$node attr -default "" href]] eq ""} return
 
+        if {[regexp {^data:text/css(;[^,]*)?,(.*)$} $href -> opts css]} {
+            # Inline stylesheet in a data: URI (e.g. the acid2
+            # "appendix stylesheet").
+            $self style add-from [$self location get] \
+                [::minhtmltk::taghelper::percent-decode $css]
+            return
+        }
+
         $self style import-from author [$self location get] $href
     }
 
@@ -32,7 +40,21 @@ snit::macro ::minhtmltk::taghelper::style {} {
         lappend stateStyleList $style
         $myHtml style -id $id \
             -importcmd [list $self style import-from $id $uri] \
+            -urlcmd [list $self style resolve-url $uri] \
             [string map [list \r ""] $style]
+    }
+
+    # Resolve url(...) values relative to the stylesheet they appear
+    # in, so that e.g. bootstrap's url("../img/glyphicons-halflings.png")
+    # reaches -imagecmd already resolved.
+    method {style resolve-url} {baseURI uri} {
+        if {[regexp {^data:} $uri]} {
+            return $uri
+        }
+        if {[catch {$self nav resolve $uri $baseURI} resolved]} {
+            return $uri
+        }
+        return $resolved
     }
 
     # @import

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -5,7 +5,7 @@
 
 # mostly borrowed from tk's tests/all.tcl
 
-package require Tcl 8.5
+package require Tcl 8.5-
 package require tcltest 2.2
 package require Tk ;# This is the Tk test suite; fail early if no Tk!
 tcltest::configure {*}$argv


### PR DESCRIPTION
- taghelper/imagecmd.tcl: new [image load] method wired to the widget via -imagecmd. Handles base64 data: URIs (with %-decoding) and local files resolved through the navigator; images are cached per URI and flushed on Reset.
- taghelper/object.tcl: render <object data=...> as a replaced element when the data attribute is a loadable image, otherwise fall through to the fallback content (possibly a nested <object>). This is the behavior the Acid2 eyes rely on.
- taghelper/style.tcl: url(...) values now resolve relative to the stylesheet they appear in (via [pathName style -urlcmd]), so e.g. bootstrap's ../img/glyphicons sprite works; <link> stylesheets in data:text/css URIs (acid2's "appendix stylesheet") are applied.
- taghelper/link.tcl: treat rel as a word list ("appendix stylesheet" applies; "alternate stylesheet" with a title does not).
- tests/all.tcl: require Tcl 8.5- so the suite runs under Tcl 9.

With tkhtml3 built from the tkhtml3-bs2 branch, minhtmltk renders the static Acid2 face pixel-identically to the official reference, and bootstrap 2.3.2 component pages render including glyphicon sprites. Test suite: 110/110 pass (xvfb-run tests/all.tcl).


Claude-Session: https://claude.ai/code/session_01XJZx6wRKz6gZGf16JjmW9t